### PR TITLE
Refactoring and renaming add ons to apps

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -28,7 +28,7 @@ Include any relevant logs
 
 **Environment (please complete the following information):**
 
-- Add-on version: [e.g. 1.0.2]
+- App version: [e.g. 1.0.2]
 - Supervisor version: [e.g.supervisor-2021.03.6]
 - Operating system [e.g. Home Assistant OS 5.12]
 

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -33,7 +33,7 @@
     {
       "matchDatasources": ["docker"],
       "commitMessagePrefix": "⬆️",
-      "commitMessageTopic": "Addon Base Image"
+      "commitMessageTopic": "App Base Image"
     },
     {
       "matchDatasources": ["github-tags"],

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,6 @@ permissions:
   packages: read
   security-events: write
 
-
 jobs:
   workflows:
     uses: casse-boubou/ha-addon-workflows/.github/workflows/app-ci.yaml@main

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,13 +3,19 @@ name: CI
 
 # yamllint disable-line rule:truthy
 on:
-  push:
   pull_request:
     types:
       - opened
       - reopened
   workflow_dispatch:
 
+permissions:
+  actions: read
+  contents: read
+  packages: read
+  security-events: write
+
+
 jobs:
   workflows:
-    uses: casse-boubou/ha-addon-workflows/.github/workflows/addon-ci.yaml@main
+    uses: casse-boubou/ha-addon-workflows/.github/workflows/app-ci.yaml@main

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -3,18 +3,30 @@ name: Deploy
 
 # yamllint disable-line rule:truthy
 on:
+  push:
+    branches:
+      - main
   release:
     types:
       - published
-  workflow_run:
-    workflows: ["CI"]
-    branches: [main]
-    types:
-      - completed
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
-  workflows:
-    uses: casse-boubou/ha-addon-workflows/.github/workflows/addon-deploy.yaml@main
+  ci:
+    permissions:
+      actions: read
+      contents: read
+      packages: read
+      security-events: write
+    uses: casse-boubou/ha-addon-workflows/.github/workflows/app-ci.yaml@main
+
+  deploy:
+    needs: ci
+    permissions:
+      contents: read
+      packages: write
+    uses: casse-boubou/ha-addon-workflows/.github/workflows/app-deploy.yaml@main
     secrets:
       DISPATCH_TOKEN: ${{ secrets.DISPATCH_TOKEN }}

--- a/.github/workflows/labels.yaml
+++ b/.github/workflows/labels.yaml
@@ -1,11 +1,14 @@
 ---
-name: Sync labels
+name: Sync Labels
 
 # yamllint disable-line rule:truthy
 on:
   schedule:
     - cron: "34 5 * * *"
   workflow_dispatch:
+
+permissions:
+  issues: write
 
 jobs:
   workflows:

--- a/.github/workflows/lock.yaml
+++ b/.github/workflows/lock.yaml
@@ -7,6 +7,10 @@ on:
     - cron: "0 9 * * *"
   workflow_dispatch:
 
+permissions:
+  issues: write
+  pull-requests: write
+
 jobs:
   workflows:
     uses: casse-boubou/ha-addon-workflows/.github/workflows/lock.yaml@main

--- a/.github/workflows/pr-labels.yaml
+++ b/.github/workflows/pr-labels.yaml
@@ -6,8 +6,11 @@ on:
   pull_request:
     types:
       - opened
+      - labeled
+      - unlabeled
       - synchronize
-  workflow_dispatch:
+
+permissions: {}
 
 jobs:
   workflows:

--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -7,6 +7,10 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write
+  pull-requests: read
+
 jobs:
   workflows:
     uses: casse-boubou/ha-addon-workflows/.github/workflows/release-drafter.yaml@main

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -7,6 +7,10 @@ on:
     - cron: "0 8 * * *"
   workflow_dispatch:
 
+permissions:
+  issues: write
+  pull-requests: write
+
 jobs:
   workflows:
     uses: casse-boubou/ha-addon-workflows/.github/workflows/stale.yaml@main

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 # MIT License
 
-Copyright (c) 2023-2025 Frosh
+Copyright (c) 2023-2026 Frosh
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Home Assistant Add-on: P2pool
+# Home Assistant App: P2pool
 
 [![GitHub Release][releases-shield]][releases]
 [![License][license-shield]](LICENSE)
@@ -10,15 +10,15 @@
 Les pages d'états et de surveillance du pool sont disponible sur <https://p2pool.io>,
 <https://p2pool.observer> ou <https://p2pool.io/mini>, <https://mini.p2pool.observer>
 
-[![Open your Home Assistant instance and show the add add-on repository dialog
+[![Open your Home Assistant instance and show the add app repository dialog
 with a specific repository URL pre-filled.][add-repo-shield]][add-repo]
-[![Open your Home Assistant instance and show the dashboard of a Supervisor add-on.][add-addon-shield]][add-addon]
+[![Open your Home Assistant instance and show the dashboard of a Supervisor app.][add-app-shield]][add-app]
 
 ## About
 
 - Pour miner sur P2Pool, un nœud Monero synchronisé utilisant monerod v0.18.0.0 ou
   plus récent est requis. Si vous n'en avez pas actuellement, vous pouvez utiliser
-  mon autre [addon Monerod][monerod] pour HomeAssistant. Ou télécharger les fichiers
+  mon autre [app Monerod][monerod] pour HomeAssistant. Ou télécharger les fichiers
   binaires officiels de Monero, [démarrer monerod sur votre PC][moneronode] et attendre
   qu'il soit entièrement synchronisé.
 - Vous devez utiliser une primary wallet address pour le minage. Les subaddresses
@@ -37,7 +37,7 @@ with a specific repository URL pre-filled.][add-repo-shield]][add-repo]
 
 Je ne suis pas dévellopeur, n'ai aucune formation de code, je suis simplement
 autodidact.
-Si vous avez une question concernant HA et ses add-ons vous pouvez consulter:
+Si vous avez une question concernant HA et ses apps vous pouvez consulter:
 
 - [Le Forum communautaire francophone][hacf] de HomeAssistant
 - [Le Forum communautaire anglophone][forum] de HomeAssistant.
@@ -82,8 +82,8 @@ SOFTWARE.
 > > _3. You should have received a copy of the GNU General Public License
 > > along with this program. If not, see <https://www.gnu.org/licenses>._
 
-[add-addon]: https://my.home-assistant.io/redirect/supervisor_addon/?addon=c751e21a_p2pool
-[add-addon-shield]: https://my.home-assistant.io/badges/supervisor_addon.svg
+[add-app]: https://my.home-assistant.io/redirect/supervisor_addon/?addon=c751e21a_p2pool
+[add-app-shield]: https://my.home-assistant.io/badges/supervisor_addon.svg
 [add-repo]: https://my.home-assistant.io/redirect/supervisor_add_addon_repository/?repository_url=https%3A//github.com/casse-boubou/hassio-addons
 [add-repo-shield]: https://my.home-assistant.io/badges/supervisor_add_addon_repository.svg
 [releases]: https://github.com/casse-boubou/addon-p2pool/releases

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Si vous avez une question concernant HA et ses apps vous pouvez consulter:
 
 MIT License
 
-Copyright (c) 2023-2025 [Frosh][Frosh]
+Copyright (c) 2023-2026 [Frosh][Frosh]
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/p2pool/.README.j2
+++ b/p2pool/.README.j2
@@ -21,7 +21,7 @@ Si vous avez une question concernant HA et ses apps vous pouvez consulter:
 
 MIT License
 
-Copyright (c) 2023-2025 [Frosh][Frosh]
+Copyright (c) 2023-2026 [Frosh][Frosh]
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/p2pool/.README.j2
+++ b/p2pool/.README.j2
@@ -1,4 +1,4 @@
-# Home Assistant Add-on: P2pool
+# Home Assistant App: P2pool
 
 [![GitHub Release][releases-shield]][releases]
 [![License][license-shield]][license]
@@ -6,12 +6,12 @@
 {% set repository = namespace(url='https%3A//github.com/casse-boubou/hassio-addons', slug='c751e21a') %}
 ## About
 
-Cet Addon vous permettra l'execution d'un pool décentralisé [p2pool][p2pool] sur votre HomeAssistant sur RaspBerry Pi 4.
+Cet App vous permettra l'execution d'un pool décentralisé [p2pool][p2pool] sur votre HomeAssistant sur RaspBerry Pi 4.
 
 ## Support
 
 Je ne suis pas dévellopeur, n'ai aucune formation de code, je suis simplement autodidact.
-Si vous avez une question concernant HA et ses add-ons vous pouvez consulter:
+Si vous avez une question concernant HA et ses apps vous pouvez consulter:
 
 - [Le Forum communautaire francophone][HACF] de HomeAssistant
 - [Le Forum communautaire anglophone][forum] de HomeAssistant.

--- a/p2pool/DOCS.md
+++ b/p2pool/DOCS.md
@@ -138,7 +138,7 @@ Si vous avez une question concernant HA et ses apps vous pouvez consulter:
 
 MIT License
 
-Copyright (c) 2023-2025 [Frosh][Frosh]
+Copyright (c) 2023-2026 [Frosh][Frosh]
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/p2pool/DOCS.md
+++ b/p2pool/DOCS.md
@@ -1,8 +1,8 @@
-# Home Assistant Add-on: P2pool
+# Home Assistant App: P2pool
 
 ## About
 
-Cet Addon vous permettra l'execution d'un pool décentralisé [p2pool][p2pool] sur
+Cet App vous permettra l'execution d'un pool décentralisé [p2pool][p2pool] sur
 votre HomeAssistant sur RaspBerry Pi 4.
 
 Pour toutes options de configuration et possibilitées d'applications, merci de vous
@@ -10,18 +10,18 @@ renseigner sur la page du projet [p2pool][p2pool].
 
 ## Installation
 
-D'habord ajoutez le repertoire à l'add-on store de HomeAssistant (`https://github.com/casse-boubou/hassio-addons`):
+D'habord ajoutez le repertoire à l'app store de HomeAssistant (`https://github.com/casse-boubou/hassio-addons`):
 
-[![Open your Home Assistant instance and show the add add-on repository dialog
+[![Open your Home Assistant instance and show the add app repository dialog
 with a specific repository URL pre-filled.][add-repo-shield]][add-repo]
 
 Ensuite recherchez P2pool dans le store et cliquez sur installer:
 
-[![Open your Home Assistant instance and show the dashboard of a Supervisor add-on.][add-addon-shield]][add-addon]
+[![Open your Home Assistant instance and show the dashboard of a Supervisor app.][add-app-shield]][add-app]
 
 ## Configuration
 
-Example add-on configuration:
+Example app configuration:
 
 ```yaml
 p2pool_conf_overrides:
@@ -45,7 +45,7 @@ des resources mémoire._
 
 Cette option vous permet de fournir une option de configuration pour personnaliser
 les configutaions avancées de P2pool qui n'ont pas été prédéfinit en tant qu'options
-d'addon paramétrable.
+d'app paramétrable.
 
 Vous pouvez voir l'ensemble complet des options disponibles ici :
 
@@ -100,7 +100,7 @@ Activez ou désactivez le transfert du port UPnP Stratum (port 3333).
 
 ### Option: `p2pool_print_status` (optional)
 
-Interval de temps, en minutes, pour lequel l'addon va afficher le statut du pool.
+Interval de temps, en minutes, pour lequel l'app va afficher le statut du pool.
 Le statut Stratum Server sera affiché tout les X minutes (X étant la valeur défini).
 Le statut Sidechain quand à lui sera affiché avec un interval minimum de 2h.
 
@@ -128,7 +128,7 @@ Vous pouvez consulter le changelog [GitHub ici][releases].
 ## Support
 
 Je ne suis pas dévellopeur, n'ai aucune formation de code, je suis simplement autodidact.
-Si vous avez une question concernant HA et ses add-ons vous pouvez consulter:
+Si vous avez une question concernant HA et ses apps vous pouvez consulter:
 
 - [Le Forum communautaire francophone][hacf] de HomeAssistant
 - [Le Forum communautaire anglophone][forum] de HomeAssistant.
@@ -173,8 +173,8 @@ SOFTWARE.
 > > _3. You should have received a copy of the GNU General Public License
 > > along with this program. If not, see <https://www.gnu.org/licenses>._
 
-[add-addon]: https://my.home-assistant.io/redirect/supervisor_addon/?addon=c751e21a_p2pool
-[add-addon-shield]: https://my.home-assistant.io/badges/supervisor_addon.svg
+[add-app]: https://my.home-assistant.io/redirect/supervisor_addon/?addon=c751e21a_p2pool
+[add-app-shield]: https://my.home-assistant.io/badges/supervisor_addon.svg
 [add-repo]: https://my.home-assistant.io/redirect/supervisor_add_addon_repository/?repository_url=https%3A%2F%2Fgithub.com%2Fcasse-boubou%2Fhassio-addons
 [add-repo-shield]: https://my.home-assistant.io/badges/supervisor_add_addon_repository.svg
 [discord-ha]: https://discord.gg/c5DvZ4e

--- a/p2pool/Dockerfile
+++ b/p2pool/Dockerfile
@@ -41,7 +41,7 @@ LABEL \
     maintainer="Frosh" \
     org.opencontainers.image.title="${BUILD_NAME}" \
     org.opencontainers.image.description="${BUILD_DESCRIPTION}" \
-    org.opencontainers.image.vendor="Frosh Home Assistant Add-ons" \
+    org.opencontainers.image.vendor="Frosh Home Assistant App" \
     org.opencontainers.image.authors="Frosh" \
     org.opencontainers.image.licenses="MIT" \
     org.opencontainers.image.url="https://github.com/casse-boubou/hassio-addons" \

--- a/p2pool/rootfs/etc/s6-overlay/s6-rc.d/p2pool/run
+++ b/p2pool/rootfs/etc/s6-overlay/s6-rc.d/p2pool/run
@@ -1,7 +1,7 @@
 #!/command/with-contenv bashio
 # shellcheck shell=bash
 # ==============================================================================
-# Home Assistant Add-on: P2pool
+# Home Assistant App: P2pool
 # Runs P2pool
 # ==============================================================================
 

--- a/p2pool/rootfs/etc/s6-overlay/s6-rc.d/status_commande/run
+++ b/p2pool/rootfs/etc/s6-overlay/s6-rc.d/status_commande/run
@@ -1,7 +1,7 @@
 #!/command/with-contenv bashio
 # shellcheck shell=bash
 # ==============================================================================
-# Home Assistant Add-on: P2pool
+# Home Assistant App: P2pool
 # Runs status_commande
 # ==============================================================================
 


### PR DESCRIPTION
# Changes

In version 2026.2, HA decided to rename its “add-ons” to “Apps.”
This update renames items in accordance with the new nomenclature.

https://www.home-assistant.io/blog/2026/02/04/release-20262/#add-ons-are-now-called-apps
Or github discussion
https://github.com/home-assistant/architecture/discussions/1287